### PR TITLE
feat: added erasmus funding information to payload

### DIFF
--- a/payload-types.ts
+++ b/payload-types.ts
@@ -75,6 +75,7 @@ export interface Config {
     "lgbtq-levels": LgbtqLevel;
     plugTypes: PlugType;
     media: Media;
+    erasmusfundings: Erasmusfunding;
     "payload-kv": PayloadKv;
     users: User;
     "payload-locked-documents": PayloadLockedDocument;
@@ -91,6 +92,7 @@ export interface Config {
     "lgbtq-levels": LgbtqLevelsSelect<false> | LgbtqLevelsSelect<true>;
     plugTypes: PlugTypesSelect<false> | PlugTypesSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
+    erasmusfundings: ErasmusfundingsSelect<false> | ErasmusfundingsSelect<true>;
     "payload-kv": PayloadKvSelect<false> | PayloadKvSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     "payload-locked-documents":
@@ -195,6 +197,7 @@ export interface Country {
     lgbtqFriendliness?: (string | null) | LgbtqLevel;
     lgbtqFriendlinessScore?: number | null;
     avgCostOfLiving?: number | null;
+    erasmusFunding?: (string | null) | Erasmusfunding;
   };
   languageAndCommunication?: {
     description?: string | null;
@@ -326,6 +329,21 @@ export interface LgbtqLevel {
   range?: string | null;
   description?: string | null;
   icon?: (string | null) | Media;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "erasmusfundings".
+ */
+export interface Erasmusfunding {
+  id: string;
+  groupName: string;
+  description?: string | null;
+  monthlyFunding: {
+    min: number;
+    max: number;
+  };
   updatedAt: string;
   createdAt: string;
 }
@@ -463,6 +481,10 @@ export interface PayloadLockedDocument {
         value: string | Media;
       } | null)
     | ({
+        relationTo: "erasmusfundings";
+        value: string | Erasmusfunding;
+      } | null)
+    | ({
         relationTo: "users";
         value: string | User;
       } | null);
@@ -544,6 +566,7 @@ export interface CountriesSelect<T extends boolean = true> {
         lgbtqFriendliness?: T;
         lgbtqFriendlinessScore?: T;
         avgCostOfLiving?: T;
+        erasmusFunding?: T;
       };
   languageAndCommunication?:
     | T
@@ -774,6 +797,22 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "erasmusfundings_select".
+ */
+export interface ErasmusfundingsSelect<T extends boolean = true> {
+  groupName?: T;
+  description?: T;
+  monthlyFunding?:
+    | T
+    | {
+        min?: T;
+        max?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -12,6 +12,7 @@ import { HazardsIndex } from "@/src/collections/HazardsIndex";
 import { UserRequests } from "@/src/collections/UserRequests";
 import { EnglishLevels } from "@/src/collections/EnglishLevels";
 import { LgbtqLevels } from "@/src/collections/LgbtqLevels";
+import ErasmusFundings from "@/src/collections/ErasmusFundings";
 
 const isProd = process.env.NODE_ENV === "production";
 
@@ -48,6 +49,7 @@ export default buildConfig({
     LgbtqLevels,
     PlugTypes,
     Media,
+    ErasmusFundings,
   ],
 
   plugins: [

--- a/src/collections/ErasmusFundings.ts
+++ b/src/collections/ErasmusFundings.ts
@@ -1,0 +1,38 @@
+import type { CollectionConfig } from "payload";
+
+export const ErasmusFundings: CollectionConfig = {
+  slug: "erasmusfundings",
+  labels: { singular: "ErasmusFunding", plural: "ErasmusFundings" },
+  admin: { useAsTitle: "groupName" },
+  fields: [
+    {
+      name: "groupName",
+      type: "text",
+      required: true,
+    },
+    {
+      name: "description",
+      type: "text",
+    },
+    {
+      name: "monthlyFunding",
+      type: "group",
+      fields: [
+        {
+          name: "min",
+          label: "Minimum (in €)",
+          type: "number",
+          required: true,
+        },
+        {
+          name: "max",
+          label: "Maximum (in €)",
+          type: "number",
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+export default ErasmusFundings;

--- a/src/collections/categories/culturalAndSocialNorms.ts
+++ b/src/collections/categories/culturalAndSocialNorms.ts
@@ -40,5 +40,12 @@ export const culturalAndSocialNorms: Field = {
       type: "number",
       min: 1,
     },
+    {
+      name: "erasmusFunding",
+      label: "Erasmus funding group",
+      type: "relationship",
+      relationTo: "erasmusfundings",
+      hasMany: false,
+    },
   ],
 };


### PR DESCRIPTION
Länder werden von der EU in 3 Länderfördergruppen [0] unterteilt und abhängig davon in welcher Gruppe ein Land ist, ergeben sich die Fördergelder. 

Da teilweise jedoch die Herkunftsländer oder die Unis aus den Herkunftsländern die Förderbeiträge bestimmen habe ich jetzt einfach eine range angegeben und jedes Land einfach der entsprechenden Gruppe hinzugefügt.

England gehört zu keiner Gruppe -> keine Erasmusförderung.

[0] https://eu.daad.de/infos-fuer-hochschulen/projektdurchfuehrung/mobilitaet-von-einzelpersonen-KA131/foerderraten-und-aufstockungsbetraege-top-ups-in-der-mobilitaet-von-einzelpersonen-ka131/de/79410-foerderraten-und-aufstockungsbetraege-top-ups-in-der-mobilitaet-von-einzelpersonen-ka131/